### PR TITLE
NS RCC config

### DIFF
--- a/Projects/b_u585i_iot02a_tfm/Src/hal_init.c
+++ b/Projects/b_u585i_iot02a_tfm/Src/hal_init.c
@@ -107,6 +107,10 @@ static void SystemClock_Config( void )
         .PLL.PLLFRACN = 0,
     };
 
+    /* Switching from one PLL configuration to another requires to temporarily restore the default RCC configuration. */
+    xResult = HAL_RCC_DeInit();
+    configASSERT( xResult == HAL_OK );
+
     xResult = HAL_RCC_OscConfig( &xRccOscInit );
     configASSERT( xResult == HAL_OK );
 


### PR DESCRIPTION
Hi,

the patch allows a safe RCC clock source reconfiguration, independently of the configuation left by the bootloader.

Regards