### PR TITLE
NS FPU access

### DIFF
--- a/Projects/b_u585i_iot02a_tfm/Src/system_stm32u5xx_ns.c
+++ b/Projects/b_u585i_iot02a_tfm/Src/system_stm32u5xx_ns.c
@@ -136,12 +136,16 @@
 
 void SystemInit(void)
 {
+#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+    SCB->CPACR |= ((3UL << (10*2))|(3UL << (11*2)));  /* set CP10 and CP11 Full Access */
+#endif
+
   /* Nothing done in non-secure */
 
   /* Non-secure main application shall call SystemCoreClockUpdate() to update */
   /* the SystemCoreClock variable to insure non-secure application relies on  */
   /* the initial clock reference set by secure application.                   */
-	SystemCoreClockUpdate();
+  SystemCoreClockUpdate();
 }
 
 /**


### PR DESCRIPTION
Hi,

this patch allows the application to use the NS FPU.
Otherwise the computation of PLL parameters, which rely on FPU instructions, produces an access fault.

Regards