### PR TITLE
Return error code if any error detected in mbedtls_ssl_send

### DIFF
--- a/Common/net/mbedtls_transport.c
+++ b/Common/net/mbedtls_transport.c
@@ -407,7 +407,7 @@ static int mbedtls_ssl_send( void * pvCtx,
         }
     }
 
-    return ( int ) uxBytesSent;
+    return ( int ) lError == 0 ? uxBytesSent : lError;
 }
 
 /*-----------------------------------------------------------*/

--- a/Common/net/mbedtls_transport.c
+++ b/Common/net/mbedtls_transport.c
@@ -407,7 +407,7 @@ static int mbedtls_ssl_send( void * pvCtx,
         }
     }
 
-    return ( int ) lError == 0 ? uxBytesSent : lError;
+    return ( int ) lError < 0 ? lError : uxBytesSent;
 }
 
 /*-----------------------------------------------------------*/


### PR DESCRIPTION
When testing transport layer, there is a test failure on "TransportSend_RemoteDisconnect".
Device can send packets to echo server after disconnetion triggered by server.

After applying this patch, I can pass test case "TransportSend_RemoteDisconnect".