### PR TITLE
launch: Use ${system_path:bash} to find bash path and add --login to launch file args.

### DIFF
--- a/Projects/b_u585i_iot02a_ntz/launch/Flash_ntz.launch
+++ b/Projects/b_u585i_iot02a_ntz/launch/Flash_ntz.launch
@@ -18,8 +18,8 @@
     <stringAttribute key="org.eclipse.cdt.launch.DEBUGGER_START_MODE" value="run"/>
     <booleanAttribute key="org.eclipse.cdt.launch.DEBUGGER_STOP_AT_MAIN" value="false"/>
     <stringAttribute key="org.eclipse.cdt.launch.DEBUGGER_STOP_AT_MAIN_SYMBOL" value="main"/>
-    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_ARGUMENTS" value="flash_ntz"/>
-    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="${workspace_loc}/tools/stm32u5_tool.sh"/>
+    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_ARGUMENTS" value="--login ${workspace_loc}/tools/stm32u5_tool.sh flash_ntz"/>
+    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="${system_path:bash}"/>
     <stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="b_u585i_iot02a_ntz"/>
     <booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="true"/>
     <stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>

--- a/Projects/b_u585i_iot02a_tfm/launch/Flash_Unlock.launch
+++ b/Projects/b_u585i_iot02a_tfm/launch/Flash_Unlock.launch
@@ -8,7 +8,7 @@
         <listEntry value="org.eclipse.ui.externaltools.launchGroup"/>
     </listAttribute>
     <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LAUNCH_CONFIGURATION_BUILD_SCOPE" value="${none}"/>
-    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${workspace_loc}/tools/stm32u5_tool.sh"/>
-    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="unlock"/>
+    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${system_path:bash}"/>
+    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="--login ${workspace_loc}/tools/stm32u5_tool.sh unlock"/>
     <stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="${workspace_loc}"/>
 </launchConfiguration>

--- a/Projects/b_u585i_iot02a_tfm/launch/Flash_tfm_bl2_s_ns.launch
+++ b/Projects/b_u585i_iot02a_tfm/launch/Flash_tfm_bl2_s_ns.launch
@@ -18,8 +18,8 @@
     <stringAttribute key="org.eclipse.cdt.launch.DEBUGGER_START_MODE" value="run"/>
     <booleanAttribute key="org.eclipse.cdt.launch.DEBUGGER_STOP_AT_MAIN" value="false"/>
     <stringAttribute key="org.eclipse.cdt.launch.DEBUGGER_STOP_AT_MAIN_SYMBOL" value="main"/>
-    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_ARGUMENTS" value="flash_tzen_all"/>
-    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="${workspace_loc}/tools/stm32u5_tool.sh"/>
+    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_ARGUMENTS" value="--login ${workspace_loc}/tools/stm32u5_tool.sh flash_tzen_all"/>
+    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="${system_path:bash}"/>
     <stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="b_u585i_iot02a_tfm"/>
     <booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
     <stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>

--- a/Projects/b_u585i_iot02a_tfm/launch/Flash_tfm_ns.launch
+++ b/Projects/b_u585i_iot02a_tfm/launch/Flash_tfm_ns.launch
@@ -18,8 +18,8 @@
     <stringAttribute key="org.eclipse.cdt.launch.DEBUGGER_START_MODE" value="run"/>
     <booleanAttribute key="org.eclipse.cdt.launch.DEBUGGER_STOP_AT_MAIN" value="false"/>
     <stringAttribute key="org.eclipse.cdt.launch.DEBUGGER_STOP_AT_MAIN_SYMBOL" value="main"/>
-    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_ARGUMENTS" value="flash_ns"/>
-    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="${workspace_loc}/tools/stm32u5_tool.sh"/>
+    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_ARGUMENTS" value="--login ${workspace_loc}/tools/stm32u5_tool.sh flash_ns"/>
+    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="${system_path:bash}"/>
     <stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="b_u585i_iot02a_tfm"/>
     <booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
     <stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>

--- a/Projects/b_u585i_iot02a_tfm/launch/Flash_tfm_ns_update.launch
+++ b/Projects/b_u585i_iot02a_tfm/launch/Flash_tfm_ns_update.launch
@@ -18,8 +18,8 @@
     <stringAttribute key="org.eclipse.cdt.launch.DEBUGGER_START_MODE" value="run"/>
     <booleanAttribute key="org.eclipse.cdt.launch.DEBUGGER_STOP_AT_MAIN" value="false"/>
     <stringAttribute key="org.eclipse.cdt.launch.DEBUGGER_STOP_AT_MAIN_SYMBOL" value="main"/>
-    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_ARGUMENTS" value="flash_ns_update"/>
-    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="${workspace_loc}/tools/stm32u5_tool.sh"/>
+    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_ARGUMENTS" value="--login ${workspace_loc}/tools/stm32u5_tool.sh flash_ns_update"/>
+    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="${system_path:bash}"/>
     <stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="b_u585i_iot02a_tfm"/>
     <booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
     <stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>

--- a/Projects/b_u585i_iot02a_tfm/launch/Flash_tfm_s_ns_update.launch
+++ b/Projects/b_u585i_iot02a_tfm/launch/Flash_tfm_s_ns_update.launch
@@ -18,8 +18,8 @@
     <stringAttribute key="org.eclipse.cdt.launch.DEBUGGER_START_MODE" value="run"/>
     <booleanAttribute key="org.eclipse.cdt.launch.DEBUGGER_STOP_AT_MAIN" value="false"/>
     <stringAttribute key="org.eclipse.cdt.launch.DEBUGGER_STOP_AT_MAIN_SYMBOL" value="main"/>
-    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_ARGUMENTS" value="flash_tzen_update"/>
-    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="${workspace_loc}/tools/stm32u5_tool.sh"/>
+    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_ARGUMENTS" value="--login ${workspace_loc}/tools/stm32u5_tool.sh flash_tzen_update"/>
+    <stringAttribute key="org.eclipse.cdt.launch.PROGRAM_NAME" value="${system_path:bash}"/>
     <stringAttribute key="org.eclipse.cdt.launch.PROJECT_ATTR" value="b_u585i_iot02a_tfm"/>
     <booleanAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_AUTO_ATTR" value="false"/>
     <stringAttribute key="org.eclipse.cdt.launch.PROJECT_BUILD_CONFIG_ID_ATTR" value=""/>

--- a/Projects/b_u585i_iot02a_tfm/launch/Trustzone_Disable.launch
+++ b/Projects/b_u585i_iot02a_tfm/launch/Trustzone_Disable.launch
@@ -8,7 +8,7 @@
         <listEntry value="org.eclipse.ui.externaltools.launchGroup"/>
     </listAttribute>
     <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LAUNCH_CONFIGURATION_BUILD_SCOPE" value="${none}"/>
-    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${workspace_loc}/tools/stm32u5_tool.sh"/>
-    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="tz_regression"/>
+    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${system_path:bash}"/>
+    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="--login ${workspace_loc}/tools/stm32u5_tool.sh tz_regression"/>
     <stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="${workspace_loc}"/>
 </launchConfiguration>

--- a/Projects/b_u585i_iot02a_tfm/launch/Trustzone_Enable.launch
+++ b/Projects/b_u585i_iot02a_tfm/launch/Trustzone_Enable.launch
@@ -8,7 +8,7 @@
         <listEntry value="org.eclipse.ui.externaltools.launchGroup"/>
     </listAttribute>
     <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LAUNCH_CONFIGURATION_BUILD_SCOPE" value="${none}"/>
-    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${workspace_loc}/tools/stm32u5_tool.sh"/>
-    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="tz_enable"/>
+    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_LOCATION" value="${system_path:bash}"/>
+    <stringAttribute key="org.eclipse.ui.externaltools.ATTR_TOOL_ARGUMENTS" value="--login ${workspace_loc}/tools/stm32u5_tool.sh tz_enable"/>
     <stringAttribute key="org.eclipse.ui.externaltools.ATTR_WORKING_DIRECTORY" value="${workspace_loc}"/>
 </launchConfiguration>


### PR DESCRIPTION

Improves windows compatibility provided that bash is in the system or user PATH.