### PR TITLE
Actory/fix tfm ota

### DIFF
--- a/Common/app/mqtt/mqtt_agent_task.c
+++ b/Common/app/mqtt/mqtt_agent_task.c
@@ -1702,12 +1702,12 @@ MQTTStatus_t MqttAgent_UnSubscribeSync( MQTTAgentHandle_t xHandle,
         {
             /* TODO: Use a reasonable timeout value here */
             xStatus = prvSendUnsubRequest( &( pxTaskCtx->xAgentContext ),
-                                        pcTopicFilter,
-                                        xTopicFilterLen,
-                                        pxSubInfo->qos,
-                                        portMAX_DELAY );
+                                           pcTopicFilter,
+                                           xTopicFilterLen,
+                                           pxSubInfo->qos,
+                                           portMAX_DELAY );
         }
-        
+
         /* Acquire mutex */
         if( xLockSubCtx( pxCtx ) )
         {

--- a/Common/app/mqtt/mqtt_agent_task.c
+++ b/Common/app/mqtt/mqtt_agent_task.c
@@ -356,7 +356,8 @@ static inline void prvCompressSubscriptionList( MQTTSubscribeInfo_t * pxSubList,
 
     for( size_t uxIdx = 0U; uxIdx < MQTT_AGENT_MAX_SUBSCRIPTIONS; uxIdx++ )
     {
-        if( ( pxSubList[ uxIdx ].topicFilterLength == 0 ) &&
+        if( ( pxSubList[ uxIdx ].pTopicFilter == NULL ) &&
+            ( pxSubList[ uxIdx ].topicFilterLength == 0 ) &&
             ( uxLastOccupiedIndex < MQTT_AGENT_MAX_SUBSCRIPTIONS ) )
         {
             if( uxLastOccupiedIndex <= uxIdx )
@@ -387,7 +388,8 @@ static inline void prvCompressSubscriptionList( MQTTSubscribeInfo_t * pxSubList,
                 }
             }
         }
-        else if( pxSubList[ uxIdx ].topicFilterLength != 0 )
+        else if( ( pxSubList[ uxIdx ].pTopicFilter != NULL ) &&
+                 ( pxSubList[ uxIdx ].topicFilterLength != 0 ) )
         {
             /* Increment count of active subscriptions */
             uxSubCount++;

--- a/Common/config/ota_config.h
+++ b/Common/config/ota_config.h
@@ -117,7 +117,7 @@
  * This configurations parameter sets the maximum number of static data buffers used by
  * the OTA agent for job and file data blocks received.
  */
-#define otaconfigMAX_NUM_OTA_DATA_BUFFERS       2U
+#define otaconfigMAX_NUM_OTA_DATA_BUFFERS       ( otaconfigMAX_NUM_BLOCKS_REQUEST + 1 )
 
 /**
  * @brief How frequently the device will report its OTA progress to the cloud.


### PR DESCRIPTION
Fix two OTA E2E test cases on TFM project.
1. OTAE2ETwoUpdatesCancelFirst
    - Enlarge the OTA buffer pool to handle unexpected message from another OTA job.
2. OTAE2ECancelThenUpdate
    - OTA data block might come between send unsubscribe message & receive unsubscribe ack. Let the callback function to handle the message correctly at that time.